### PR TITLE
Proxy Policies

### DIFF
--- a/config/.proxy-example.json
+++ b/config/.proxy-example.json
@@ -2,27 +2,63 @@
 	"routes": [
 		{
 			"endpoint": "/",
-			"backend": "http://localhost:9100"
+      "backend": "http://localhost:9100",
+      "policy": "reva"
 		},
 		{
-			"endpoint": "/.well-known/openid-configuration",
-			"backend": "http://localhost:9130"
+			"endpoint": "/.well-known/",
+      "backend": "http://localhost:9130",
+      "policy": "reva"
 		},
 		{
 			"endpoint": "/konnect/",
-			"backend": "http://localhost:9130"
+      "backend": "http://localhost:9130",
+      "policy": "reva"
 		},
 		{
 			"endpoint": "/signin/",
-			"backend": "http://localhost:9130"
+      "backend": "http://localhost:9130",
+      "policy": "reva"
 		},
 		{
 			"endpoint": "/ocs/v1.php/",
-			"backend": "http://localhost:4444"
+      "backend": "http://localhost:9140",
+      "policy": "reva"
 		},
 		{
 			"endpoint": "/remote.php/webdav/",
-			"backend": "http://localhost:4444"
+      "backend": "http://localhost:9140",
+      "policy": "reva"
+    },
+		{
+			"endpoint": "/",
+      "backend": "http://localhost:9100",
+      "policy": "oc10"
+		},
+		{
+			"endpoint": "/.well-known/",
+      "backend": "http://localhost:9130",
+      "policy": "oc10"
+		},
+		{
+			"endpoint": "/konnect/",
+      "backend": "http://localhost:9130",
+      "policy": "oc10"
+		},
+		{
+			"endpoint": "/signin/",
+      "backend": "http://localhost:9130",
+      "policy": "oc10"
+		},
+		{
+			"endpoint": "/ocs/v1.php/",
+      "backend": "http://localhost:9140",
+      "policy": "oc10"
+		},
+		{
+			"endpoint": "/remote.php/webdav/",
+      "backend": "http://localhost:9140",
+      "policy": "oc10"
 		}
 	]
 }

--- a/config/.proxy-example.json
+++ b/config/.proxy-example.json
@@ -1,64 +1,62 @@
 {
-	"routes": [
-		{
-			"endpoint": "/",
-      "backend": "http://localhost:9100",
-      "policy": "reva"
-		},
-		{
-			"endpoint": "/.well-known/",
-      "backend": "http://localhost:9130",
-      "policy": "reva"
-		},
-		{
-			"endpoint": "/konnect/",
-      "backend": "http://localhost:9130",
-      "policy": "reva"
-		},
-		{
-			"endpoint": "/signin/",
-      "backend": "http://localhost:9130",
-      "policy": "reva"
-		},
-		{
-			"endpoint": "/ocs/v1.php/",
-      "backend": "http://localhost:9140",
-      "policy": "reva"
-		},
-		{
-			"endpoint": "/remote.php/webdav/",
-      "backend": "http://localhost:9140",
-      "policy": "reva"
+  "policies": [
+    {
+      "name": "reva",
+      "routes": [
+        {
+          "endpoint": "/",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/.well-known/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/konnect/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/signin/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/ocs/v1.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/remote.php/webdav/",
+          "backend": "http://localhost:9140"
+        }
+      ]
     },
-		{
-			"endpoint": "/",
-      "backend": "http://localhost:9100",
-      "policy": "oc10"
-		},
-		{
-			"endpoint": "/.well-known/",
-      "backend": "http://localhost:9130",
-      "policy": "oc10"
-		},
-		{
-			"endpoint": "/konnect/",
-      "backend": "http://localhost:9130",
-      "policy": "oc10"
-		},
-		{
-			"endpoint": "/signin/",
-      "backend": "http://localhost:9130",
-      "policy": "oc10"
-		},
-		{
-			"endpoint": "/ocs/v1.php/",
-      "backend": "http://localhost:9140",
-      "policy": "oc10"
-		},
-		{
-			"endpoint": "/remote.php/webdav/",
-      "backend": "http://localhost:9140",
-      "policy": "oc10"
-		}
-	]
+    {
+      "name": "oc10",
+      "routes": [
+        {
+          "endpoint": "/",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/.well-known/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/konnect/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/signin/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/ocs/v1.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/remote.php/webdav/",
+          "backend": "http://localhost:9140"
+        }
+      ]
+    }
+  ]
 }

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/oklog/run v1.1.0
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/owncloud/ocis-konnectd v0.0.0-20200303180152-937016f63393
-	github.com/owncloud/ocis-pkg/v2 v2.0.1
+	github.com/owncloud/ocis-pkg/v2 v2.0.2
 	github.com/prometheus/client_golang v1.2.1
 	github.com/restic/calens v0.2.0
-	github.com/spf13/viper v1.6.1
+	github.com/spf13/viper v1.6.2
 	go.opencensus.io v0.22.2
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/micro/go-micro/v2 v2.0.1-0.20200212105717-d76baf59de2e // indirect
 	github.com/oklog/run v1.1.0
 	github.com/openzipkin/zipkin-go v0.2.2
-	github.com/owncloud/ocis-konnectd v0.0.0-20200221141628-e8420f55da5a
+	github.com/owncloud/ocis-konnectd v0.0.0-20200303180152-937016f63393
 	github.com/owncloud/ocis-pkg/v2 v2.0.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/restic/calens v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -474,6 +474,8 @@ github.com/owncloud/ocis-konnectd v0.0.0-20200303180152-937016f63393 h1:JqnnJAVS
 github.com/owncloud/ocis-konnectd v0.0.0-20200303180152-937016f63393/go.mod h1:RSm/AcbZ+Wq608qRGW28Rp95ktn4Hxi9BvY2c9aj7lU=
 github.com/owncloud/ocis-pkg/v2 v2.0.1 h1:3ISEtfjAz4pDFczTggIJwKuft3bVsAp1C7dFY9BBPEs=
 github.com/owncloud/ocis-pkg/v2 v2.0.1/go.mod h1:7bVnn3VUaqdmvpMkXF0QVEF1fRugs35hSkuVTAq9yjk=
+github.com/owncloud/ocis-pkg/v2 v2.0.2 h1:aHqvuRXMFsImO/uwL9v8Ul+PByPFLZp/Rdj4MXAhI9A=
+github.com/owncloud/ocis-pkg/v2 v2.0.2/go.mod h1:7bVnn3VUaqdmvpMkXF0QVEF1fRugs35hSkuVTAq9yjk=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
@@ -576,6 +578,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.6.1 h1:VPZzIkznI1YhVMRi6vNFLHSwhnhReBfgTxIPccpfdZk=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
+github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OpenDNS/vegadns2client v0.0.0-20180418235048-a3fa4a771d87/go.mod h1:iGLljf5n9GjT6kc0HBvyI1nOKnGQbNB66VzSNbK5iks=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/UnnoTed/fileb0x v1.1.4 h1:IUgFzgBipF/ujNx9wZgkrKOF3oltUuXMSoaejrBws+A=
 github.com/UnnoTed/fileb0x v1.1.4/go.mod h1:X59xXT18tdNk/D6j+KZySratBsuKJauMtVuJ9cgOiZs=
 github.com/akamai/AkamaiOPEN-edgegrid-golang v0.9.0/go.mod h1:zpDJeKyp9ScW4NNrbdr+Eyxvry3ilGPewKoXw3XGN1k=
 github.com/alangpierce/go-forceexport v0.0.0-20160317203124-8f1d6941cd75 h1:3ILjVyslFbc4jl1w5TWuvvslFD/nDfR2H8tVaMVLrEY=
@@ -77,6 +78,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar v1.1.1 h1:YroD6BJCZBYx06yYFEWvUuKVWQn3vLLQAVmDmvTSaiQ=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
@@ -168,6 +170,7 @@ github.com/fsouza/go-dockerclient v1.4.4/go.mod h1:PrwszSL5fbmsESocROrOGq/NULMXR
 github.com/fsouza/go-dockerclient v1.6.0/go.mod h1:YWwtNPuL4XTX1SKJQk86cWPmmqwx+4np9qfPbb+znGc=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
 github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-acme/lego/v3 v3.1.0/go.mod h1:074uqt+JS6plx+c9Xaiz6+L+GBb+7itGtzfcDM2AhEE=
@@ -250,6 +253,8 @@ github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -304,6 +309,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
+github.com/karrick/godirwalk v1.7.8 h1:VfG72pyIxgtC7+3X9CMHI0AOl4LwyRAg98WAgsvffi8=
 github.com/karrick/godirwalk v1.7.8/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -323,7 +329,9 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/labbsr0x/bindman-dns-webhook v1.0.2/go.mod h1:p6b+VCXIR8NYKpDr8/dg1HKfQoRHCdcsROXKvmoehKA=
 github.com/labbsr0x/goh v1.0.1/go.mod h1:8K2UhVoaWXcCU7Lxoa2omWnC8gyW8px7/lmO61c027w=
+github.com/labstack/echo v3.2.1+incompatible h1:J2M7YArHx4gi8p/3fDw8tX19SXhBCoRpviyAZSN3I88=
 github.com/labstack/echo v3.2.1+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/gommon v0.2.7 h1:2qOPq/twXDrQ6ooBGrn3mrmVOC+biLlatwgIu8lbzRM=
 github.com/labstack/gommon v0.2.7/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -349,12 +357,15 @@ github.com/marten-seemann/qtls v0.3.2/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwm
 github.com/marten-seemann/qtls v0.4.1 h1:YlT8QP3WCCvvok7MGEZkMldXbyqgr8oFg5/n8Gtbkks=
 github.com/marten-seemann/qtls v0.4.1/go.mod h1:pxVXcHHw1pNIt8Qo0pwSYQEoZ8yYOOPXTCZLQQunvRc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-tty v0.0.0-20180219170247-931426f7535a/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -391,6 +402,7 @@ github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFW
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed/go.mod h1:3rdaFaCv4AyBgu5ALFM0+tSuHrBh6v692nyQe3ikrq0=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
@@ -431,6 +443,7 @@ github.com/nrdcg/auroradns v1.0.0/go.mod h1:6JPXKzIRzZzMqtTDgueIhTi6rFf1QvYE/Hzq
 github.com/nrdcg/dnspod-go v0.3.0/go.mod h1:vZSoFSFeQVm2gWLMkyX61LZ8HI3BaqtHZWgPTGKr6KQ=
 github.com/nrdcg/goinwx v0.6.1/go.mod h1:XPiut7enlbEdntAqalBIqcYcTEVhpv/dKWgDCX2SwKQ=
 github.com/nrdcg/namesilo v0.2.1/go.mod h1:lwMvfQTyYq+BbjJd30ylEG4GPSS6PII0Tia4rRpRiyw=
+github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d h1:x3S6kxmy49zXVVyhcnrFqxvNVCBPb2KZ9hV2RBdS840=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
@@ -457,9 +470,8 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/oracle/oci-go-sdk v7.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/ovh/go-ovh v0.0.0-20181109152953-ba5adb4cf014/go.mod h1:joRatxRJaZBsY3JAOEMcoOp05CnZzsx4scTxi95DHyQ=
-github.com/owncloud/ocis-konnectd v0.0.0-20200221141628-e8420f55da5a h1:Msdczqy0Mt8bPxARn9NiW8Why52zDR10Aw2IZk6gsVc=
-github.com/owncloud/ocis-konnectd v0.0.0-20200221141628-e8420f55da5a/go.mod h1:lfo4oitFbpuHHLCTXrBC/93GP72cpBUokxrVqDgsyQk=
-github.com/owncloud/ocis-pkg v1.3.0 h1:2fkgvfd/spTjschuulYMHRuzxkCGGXae9ocebVYkm74=
+github.com/owncloud/ocis-konnectd v0.0.0-20200303180152-937016f63393 h1:JqnnJAVSnUB+2Lb20+DjNn553Rvvh1gsEqDfE8+ppK8=
+github.com/owncloud/ocis-konnectd v0.0.0-20200303180152-937016f63393/go.mod h1:RSm/AcbZ+Wq608qRGW28Rp95ktn4Hxi9BvY2c9aj7lU=
 github.com/owncloud/ocis-pkg/v2 v2.0.1 h1:3ISEtfjAz4pDFczTggIJwKuft3bVsAp1C7dFY9BBPEs=
 github.com/owncloud/ocis-pkg/v2 v2.0.1/go.mod h1:7bVnn3VUaqdmvpMkXF0QVEF1fRugs35hSkuVTAq9yjk=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
@@ -591,7 +603,9 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/vultr/govultr v0.1.4/go.mod h1:9H008Uxr/C4vFNGLqKx232C206GL0PBHzOP0809bGNA=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
@@ -705,6 +719,8 @@ golang.org/x/net v0.0.0-20191109021931-daa7c04131f5/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCTu3mcIURZfNkVweuRKA=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -237,11 +237,13 @@ func Server(cfg *config.Config) *cli.Command {
 func NewMultiHostReverseProxy(conf *config.Config) *ReverseProxy {
 	reverseProxy := &ReverseProxy{Directors: make(map[string]map[string]func(req *gohttp.Request))}
 
-	for _, target := range conf.Routes {
-		uri, err := url.Parse(target.Backend)
-		if err != nil { /* do something with err */
+	for _, policy := range conf.Policies {
+		for _, route := range policy.Routes {
+			uri, err := url.Parse(route.Backend)
+			if err != nil { /* do something with err */
+			}
+			reverseProxy.AddHost(policy.Name, uri, route.Endpoint)
 		}
-		reverseProxy.AddHost(target.Policy, uri, target.Endpoint)
 	}
 
 	return reverseProxy

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	gohttp "net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
@@ -25,6 +26,12 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 )
+
+// ReverseProxy extends httputil to support multiple hosts with diffent policies
+type ReverseProxy struct {
+	httputil.ReverseProxy
+	Directors map[string]map[string]func(req *gohttp.Request)
+}
 
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
@@ -135,8 +142,11 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
+			rp := NewMultiHostReverseProxy(cfg)
+
 			{
 				server, err := http.Server(
+					http.Handler(rp),
 					http.Logger(logger),
 					http.Namespace(httpNamespace),
 					http.Context(ctx),
@@ -145,17 +155,6 @@ func Server(cfg *config.Config) *cli.Command {
 					http.Flags(flagset.RootWithConfig(cfg)),
 					http.Flags(flagset.ServerWithConfig(cfg)),
 				)
-
-				for _, ep := range cfg.Routes {
-					uri, err := url.Parse(ep.Backend)
-					if err != nil {
-						logger.Info().
-							Str("server", "http").
-							Msg("error while parsing URL")
-					}
-
-					server.Handle(ep.Endpoint, httputil.NewSingleHostReverseProxy(uri))
-				}
 
 				if err != nil {
 					logger.Error().
@@ -232,4 +231,73 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
+}
+
+// NewMultiHostReverseProxy undocummented
+func NewMultiHostReverseProxy(conf *config.Config) *ReverseProxy {
+	reverseProxy := &ReverseProxy{Directors: make(map[string]map[string]func(req *gohttp.Request))}
+
+	for _, target := range conf.Routes {
+		uri, err := url.Parse(target.Backend)
+		if err != nil { /* do something with err */
+		}
+		reverseProxy.AddHost(target.Policy, uri, target.Endpoint)
+	}
+
+	return reverseProxy
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+// AddHost undocumented
+func (p *ReverseProxy) AddHost(policy string, target *url.URL, endpoint string) {
+	targetQuery := target.RawQuery
+	if p.Directors[policy] == nil {
+		p.Directors[policy] = make(map[string]func(req *gohttp.Request))
+	}
+	p.Directors[policy][endpoint] = func(req *gohttp.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+}
+
+func (p *ReverseProxy) ServeHTTP(rw gohttp.ResponseWriter, req *gohttp.Request) {
+	// TODO need to fetch from the accounts service
+	policy := "reva"
+	var hit bool
+
+	for k := range p.Directors[policy] {
+		if strings.HasPrefix(req.URL.Path, k) && k != "/" {
+			p.Director = p.Directors[policy][k]
+			hit = true
+		}
+	}
+
+	// override default director with root. If any
+	if !hit && p.Directors[policy]["/"] != nil {
+		p.Director = p.Directors[policy]["/"]
+	}
+
+	// Call upstream ServeHTTP
+	p.ReverseProxy.ServeHTTP(rw, req)
 }

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -151,7 +151,7 @@ func Server(cfg *config.Config) *cli.Command {
 					if err != nil {
 						logger.Info().
 							Str("server", "http").
-							Msg("parsing uri")
+							Msg("error while parsing URL")
 					}
 
 					server.Handle(ep.Endpoint, httputil.NewSingleHostReverseProxy(uri))

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -2,9 +2,6 @@ package command
 
 import (
 	"context"
-	gohttp "net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -21,17 +18,12 @@ import (
 	"github.com/owncloud/ocis-proxy/pkg/config"
 	"github.com/owncloud/ocis-proxy/pkg/flagset"
 	"github.com/owncloud/ocis-proxy/pkg/metrics"
+	"github.com/owncloud/ocis-proxy/pkg/proxy"
 	"github.com/owncloud/ocis-proxy/pkg/server/debug"
 	"github.com/owncloud/ocis-proxy/pkg/server/http"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 )
-
-// ReverseProxy extends httputil to support multiple hosts with diffent policies
-type ReverseProxy struct {
-	httputil.ReverseProxy
-	Directors map[string]map[string]func(req *gohttp.Request)
-}
 
 // Server is the entrypoint for the server command.
 func Server(cfg *config.Config) *cli.Command {
@@ -142,7 +134,7 @@ func Server(cfg *config.Config) *cli.Command {
 
 			defer cancel()
 
-			rp := NewMultiHostReverseProxy(cfg)
+			rp := proxy.NewMultiHostReverseProxy(cfg)
 
 			{
 				server, err := http.Server(
@@ -231,75 +223,4 @@ func Server(cfg *config.Config) *cli.Command {
 			return gr.Run()
 		},
 	}
-}
-
-// NewMultiHostReverseProxy undocummented
-func NewMultiHostReverseProxy(conf *config.Config) *ReverseProxy {
-	reverseProxy := &ReverseProxy{Directors: make(map[string]map[string]func(req *gohttp.Request))}
-
-	for _, policy := range conf.Policies {
-		for _, route := range policy.Routes {
-			uri, err := url.Parse(route.Backend)
-			if err != nil { /* do something with err */
-			}
-			reverseProxy.AddHost(policy.Name, uri, route.Endpoint)
-		}
-	}
-
-	return reverseProxy
-}
-
-func singleJoiningSlash(a, b string) string {
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-	switch {
-	case aslash && bslash:
-		return a + b[1:]
-	case !aslash && !bslash:
-		return a + "/" + b
-	}
-	return a + b
-}
-
-// AddHost undocumented
-func (p *ReverseProxy) AddHost(policy string, target *url.URL, endpoint string) {
-	targetQuery := target.RawQuery
-	if p.Directors[policy] == nil {
-		p.Directors[policy] = make(map[string]func(req *gohttp.Request))
-	}
-	p.Directors[policy][endpoint] = func(req *gohttp.Request) {
-		req.URL.Scheme = target.Scheme
-		req.URL.Host = target.Host
-		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
-		if targetQuery == "" || req.URL.RawQuery == "" {
-			req.URL.RawQuery = targetQuery + req.URL.RawQuery
-		} else {
-			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
-		}
-		if _, ok := req.Header["User-Agent"]; !ok {
-			// explicitly disable User-Agent so it's not set to default value
-			req.Header.Set("User-Agent", "")
-		}
-	}
-}
-
-func (p *ReverseProxy) ServeHTTP(rw gohttp.ResponseWriter, req *gohttp.Request) {
-	// TODO need to fetch from the accounts service
-	policy := "reva"
-	var hit bool
-
-	for k := range p.Directors[policy] {
-		if strings.HasPrefix(req.URL.Path, k) && k != "/" {
-			p.Director = p.Directors[policy][k]
-			hit = true
-		}
-	}
-
-	// override default director with root. If any
-	if !hit && p.Directors[policy]["/"] != nil {
-		p.Director = p.Directors[policy]["/"]
-	}
-
-	// Call upstream ServeHTTP
-	p.ReverseProxy.ServeHTTP(rw, req)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,22 +36,27 @@ type Asset struct {
 	Path string
 }
 
+// Policy enables us to use multiple directors.
+type Policy struct {
+	Name   string  `json:"name"`
+	Routes []Route `json:"routes"`
+}
+
 // Route define forwarding routes
 type Route struct {
 	Endpoint string `json:"endpoint"`
 	Backend  string `json:"backend"`
-	Policy   string `json:"policy"`
 }
 
 // Config combines all available configuration parts.
 type Config struct {
-	File    string
-	Log     Log
-	Debug   Debug
-	HTTP    HTTP
-	Tracing Tracing
-	Asset   Asset
-	Routes  []Route `json:"routes"`
+	File     string
+	Log      Log
+	Debug    Debug
+	HTTP     HTTP
+	Tracing  Tracing
+	Asset    Asset
+	Policies []Policy `json:"policies"`
 }
 
 // New initializes a new configuration with or without defaults.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type Asset struct {
 type Route struct {
 	Endpoint string `json:"endpoint"`
 	Backend  string `json:"backend"`
+	Policy   string `json:"policy"`
 }
 
 // Config combines all available configuration parts.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/owncloud/ocis-proxy/pkg/config"
+)
+
+// MultiHostReverseProxy extends httputil to support multiple hosts with diffent policies
+type MultiHostReverseProxy struct {
+	httputil.ReverseProxy
+	Directors map[string]map[string]func(req *http.Request)
+}
+
+// NewMultiHostReverseProxy undocummented
+func NewMultiHostReverseProxy(conf *config.Config) *MultiHostReverseProxy {
+	reverseProxy := &MultiHostReverseProxy{Directors: make(map[string]map[string]func(req *http.Request))}
+
+	for _, policy := range conf.Policies {
+		for _, route := range policy.Routes {
+			uri, err := url.Parse(route.Backend)
+			if err != nil { /* do something with err */
+			}
+			reverseProxy.AddHost(policy.Name, uri, route.Endpoint)
+		}
+	}
+
+	return reverseProxy
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+// AddHost undocumented
+func (p *MultiHostReverseProxy) AddHost(policy string, target *url.URL, endpoint string) {
+	targetQuery := target.RawQuery
+	if p.Directors[policy] == nil {
+		p.Directors[policy] = make(map[string]func(req *http.Request))
+	}
+	p.Directors[policy][endpoint] = func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
+		if targetQuery == "" || req.URL.RawQuery == "" {
+			req.URL.RawQuery = targetQuery + req.URL.RawQuery
+		} else {
+			req.URL.RawQuery = targetQuery + "&" + req.URL.RawQuery
+		}
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+}
+
+func (p *MultiHostReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO need to fetch from the accounts service
+	policy := "reva"
+	var hit bool
+
+	for k := range p.Directors[policy] {
+		if strings.HasPrefix(r.URL.Path, k) && k != "/" {
+			p.Director = p.Directors[policy][k]
+			hit = true
+		}
+	}
+
+	// override default director with root. If any
+	if !hit && p.Directors[policy]["/"] != nil {
+		p.Director = p.Directors[policy]["/"]
+	}
+
+	// Call upstream ServeHTTP
+	p.ReverseProxy.ServeHTTP(w, r)
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -26,7 +26,11 @@ func NewMultiHostReverseProxy(conf *config.Config) *MultiHostReverseProxy {
 	for _, policy := range conf.Policies {
 		for _, route := range policy.Routes {
 			uri, err := url.Parse(route.Backend)
-			if err != nil { /* do something with err */
+			if err != nil {
+				logger.
+					Fatal().
+					Err(err).
+					Msgf("malformed url: %v", route.Backend)
 			}
 			reverseProxy.AddHost(policy.Name, uri, route.Endpoint)
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -6,8 +6,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/owncloud/ocis-pkg/v2/log"
 	"github.com/owncloud/ocis-proxy/pkg/config"
 )
+
+// initialize a local logger instance
+var logger = log.NewLogger()
 
 // MultiHostReverseProxy extends httputil to support multiple hosts with diffent policies
 type MultiHostReverseProxy struct {
@@ -67,8 +71,14 @@ func (p *MultiHostReverseProxy) AddHost(policy string, target *url.URL, endpoint
 
 func (p *MultiHostReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO need to fetch from the accounts service
-	policy := "reva"
 	var hit bool
+	policy := "reva"
+
+	if _, ok := p.Directors[policy]; !ok {
+		logger.
+			Error().
+			Msgf("policy %v is not configured", policy)
+	}
 
 	for k := range p.Directors[policy] {
 		if strings.HasPrefix(r.URL.Path, k) && k != "/" {

--- a/pkg/server/http/option.go
+++ b/pkg/server/http/option.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis-pkg/v2/log"
@@ -17,6 +18,7 @@ type Options struct {
 	Logger    log.Logger
 	Context   context.Context
 	Config    *config.Config
+	Handler   http.Handler
 	Metrics   *metrics.Metrics
 	Flags     []cli.Flag
 	Namespace string
@@ -72,5 +74,12 @@ func Flags(val []cli.Flag) Option {
 func Namespace(val string) Option {
 	return func(o *Options) {
 		o.Namespace = val
+	}
+}
+
+// Handler provides a function to set the Handler option.
+func Handler(h http.Handler) Option {
+	return func(o *Options) {
+		o.Handler = h
 	}
 }

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -26,6 +26,7 @@ func Server(opts ...Option) (svc.Service, error) {
 
 	service := svc.NewService(
 		svc.Name("web.proxy"),
+		svc.Handler(options.Handler),
 		svc.TLSConfig(config),
 		svc.Logger(options.Logger),
 		svc.Namespace(options.Namespace),


### PR DESCRIPTION
# What?
Route the user to X or Y backend depending on the accounts service.

## How?

`ocis-proxy` config allows to specify a policy for a given user. By fetching the user info from the accounts service and deciding where to route the user to.

```json
{
    "policies": [
        {
            "name": "reva",
            "routes": [
                {
                    "endpoint": "/",
                    "backend": "http://localhost:9100"
                },
                {
                    "endpoint": "/.well-known/",
                    "backend": "http://localhost:9130"
                }
            ]
        },
        {
            "name": "oc10",
            "routes": [
                {
                    "endpoint": "/",
                    "backend": "http://localhost:9100"
                },
                {
                    "endpoint": "/.well-known/",
                    "backend": "http://localhost:9131"
                }
            ]
        }
    ]
}
```

so regarding the user policy we use a redirect set or another.

# Note

This depends on an update of `ocis-pkg` that adds the handler option to the service, at the moment I override the import, but this PR MUST be merged first for the proxy to work.

### ideas from

http://blog.utahcon.com/posts/reverse-proxy/