### PR TITLE
Move Before hook from root to server command

### DIFF
--- a/changelog/unreleased/move-before-to-server.md
+++ b/changelog/unreleased/move-before-to-server.md
@@ -1,0 +1,8 @@
+Change: Move Before hook from root to server command
+
+This is needed because he before hook which initializes the config is not executed correctly in the root cmd if
+the service is called from the ocis single-binary.
+
+With this commit the --config-file argument needs to be passed to the server sub-command.
+
+https://github.com/owncloud/ocis/issues/139

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -1,15 +1,12 @@
 package command
 
 import (
-	"os"
-	"strings"
-
 	"github.com/micro/cli/v2"
 	"github.com/owncloud/ocis-pkg/v2/log"
 	"github.com/owncloud/ocis-proxy/pkg/config"
 	"github.com/owncloud/ocis-proxy/pkg/flagset"
 	"github.com/owncloud/ocis-proxy/pkg/version"
-	"github.com/spf13/viper"
+	"os"
 )
 
 // Execute is the entry point for the ocis-proxy command.
@@ -30,48 +27,6 @@ func Execute() error {
 		},
 
 		Flags: flagset.RootWithConfig(cfg),
-
-		Before: func(c *cli.Context) error {
-			logger := NewLogger(cfg)
-
-			viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-			viper.SetEnvPrefix("PROXY")
-			viper.AutomaticEnv()
-
-			if c.IsSet("config-file") {
-				viper.SetConfigFile(c.String("config-file"))
-			} else {
-				viper.SetConfigName("proxy")
-
-				viper.AddConfigPath("/etc/ocis")
-				viper.AddConfigPath("$HOME/.ocis")
-				viper.AddConfigPath("./config")
-			}
-
-			if err := viper.ReadInConfig(); err != nil {
-				switch err.(type) {
-				case viper.ConfigFileNotFoundError:
-					logger.Info().
-						Msg("Continue without config")
-				case viper.UnsupportedConfigError:
-					logger.Fatal().
-						Err(err).
-						Msg("Unsupported config type")
-				default:
-					logger.Fatal().
-						Err(err).
-						Msg("Failed to read config")
-				}
-			}
-
-			if err := viper.Unmarshal(&cfg); err != nil {
-				logger.Fatal().
-					Err(err).
-					Msg("Failed to parse config")
-			}
-
-			return nil
-		},
 
 		Commands: []*cli.Command{
 			Server(cfg),

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -9,13 +9,6 @@ import (
 func RootWithConfig(cfg *config.Config) []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
-			Name:        "config-file",
-			Value:       "",
-			Usage:       "Path to config file",
-			EnvVars:     []string{"PROXY_CONFIG_FILE"},
-			Destination: &cfg.File,
-		},
-		&cli.StringFlag{
 			Name:        "log-level",
 			Value:       "info",
 			Usage:       "Set logging level",
@@ -142,6 +135,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "Set the base namespace for the http namespace",
 			EnvVars:     []string{"PROXY_HTTP_NAMESPACE"},
 			Destination: &cfg.HTTP.Namespace,
+		},
+		&cli.StringFlag{
+			Name:        "config-file",
+			Value:       "",
+			Usage:       "Path to config file",
+			EnvVars:     []string{"PROXY_CONFIG_FILE"},
+			Destination: &cfg.File,
 		},
 	}
 }


### PR DESCRIPTION
This is needed because he before hook which initializes the config is not executed correctly in the root cmd if the service is called from single-binary.

This aligns the behavior to match other commands. With this commit the --config-file argument needs to be passed to the
server sub-command.

Issue: https://github.com/owncloud/ocis/issues/139

/cc @micbar 