### PR TITLE
Add Default set of Policies

### DIFF
--- a/changelog/unreleased/runtime-policies.md
+++ b/changelog/unreleased/runtime-policies.md
@@ -1,0 +1,7 @@
+Enhancement: Load Proxy Policies at Runtime
+
+While a proxy without policies is of no use, the current state of ocis-proxy expects a config file either at an expected Viper location or specified via -- config-file flag.
+To ease deployments and ensure a working set of policies out of the box we need a series of defaults.
+
+https://github.com/owncloud/ocis-proxy/issues/17
+https://github.com/owncloud/ocis-proxy/pull/16

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,15 +38,15 @@ type Asset struct {
 
 // Policy enables us to use multiple directors.
 type Policy struct {
-	Name   string  `mapstructure:"name"`
-	Routes []Route `mapstructure:"routes"`
+	Name   string
+	Routes []Route
 }
 
 // Route define forwarding routes
 type Route struct {
-	Endpoint    string `mapstructure:"endpoint"`
-	Backend     string `mapstructure:"backend"`
-	ApacheVHost bool   `mapstructure:"apache-vhost"`
+	Endpoint    string
+	Backend     string
+	ApacheVHost bool `mapstructure:"apache-vhost"`
 }
 
 // Config combines all available configuration parts.
@@ -57,7 +57,7 @@ type Config struct {
 	HTTP     HTTP
 	Tracing  Tracing
 	Asset    Asset
-	Policies []Policy `mapstructure:"policies"`
+	Policies []Policy
 }
 
 // New initializes a new configuration

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -28,6 +28,7 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 
 	for _, policy := range options.Config.Policies {
 		for _, route := range policy.Routes {
+			reverseProxy.logger.Debug().Str("fwd: ", route.Endpoint)
 			uri, err := url.Parse(route.Backend)
 			if err != nil {
 				reverseProxy.logger.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -26,6 +26,10 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 		logger:    options.Logger,
 	}
 
+	if options.Config.Policies == nil {
+		reverseProxy.logger.Debug().Msg("config file not provided")
+	}
+
 	for _, policy := range options.Config.Policies {
 		for _, route := range policy.Routes {
 			reverseProxy.logger.Debug().Str("fwd: ", route.Endpoint)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,39 +21,39 @@ type MultiHostReverseProxy struct {
 func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 	options := newOptions(opts...)
 
-	reverseProxy := &MultiHostReverseProxy{
+	rp := &MultiHostReverseProxy{
 		Directors: make(map[string]map[string]func(req *http.Request)),
 		logger:    options.Logger,
 	}
 
 	if options.Config.Policies == nil {
-		reverseProxy.logger.Info().Str("policies source", "runtime").Msg("policies provided at runtime")
+		rp.logger.Info().Str("source", "runtime").Msg("Policies")
 		options.Config.Policies = defaultPolicies()
 	} else {
-		reverseProxy.logger.Info().Str("policies source", "config file").Msg("policies provided from config file")
+		rp.logger.Info().Str("source", "file").Msg("Policies")
 	}
 
 	for _, policy := range options.Config.Policies {
 		for _, route := range policy.Routes {
-			reverseProxy.logger.Debug().Str("fwd: ", route.Endpoint)
+			rp.logger.Debug().Str("fwd: ", route.Endpoint)
 			uri, err := url.Parse(route.Backend)
 			if err != nil {
-				reverseProxy.logger.
+				rp.logger.
 					Fatal().
 					Err(err).
 					Msgf("malformed url: %v", route.Backend)
 			}
 
-			reverseProxy.logger.
+			rp.logger.
 				Debug().
 				Interface("route", route).
 				Msg("adding route")
 
-			reverseProxy.AddHost(policy.Name, uri, route)
+			rp.AddHost(policy.Name, uri, route)
 		}
 	}
 
-	return reverseProxy
+	return rp
 }
 
 func singleJoiningSlash(a, b string) string {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -27,8 +27,10 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 	}
 
 	if options.Config.Policies == nil {
-		reverseProxy.logger.Debug().Msg("config file not provided, using oCIS embedded set of redirects")
+		reverseProxy.logger.Info().Str("policies source", "runtime").Msg("policies provided at runtime")
 		options.Config.Policies = defaultPolicies()
+	} else {
+		reverseProxy.logger.Info().Str("policies source", "config file").Msg("policies provided from config file")
 	}
 
 	for _, policy := range options.Config.Policies {


### PR DESCRIPTION
As it currently is, policies need to be read from a config file. No config file, no policies. This PR ships the default config values with a set of minimal defaults ensured to play nice with oCIS single binary.

### TODO

- [x] changelog

closes https://github.com/owncloud/ocis-proxy/issues/17