### PR TITLE
Fix token in request

### DIFF
--- a/changelog/unreleased/jwt-secret-config
+++ b/changelog/unreleased/jwt-secret-config
@@ -1,0 +1,5 @@
+Enhancement: Make jwt secret configurable
+
+We added a config option for the reva token manager JWTSecret. It was hardcoded before and is now configurable.
+
+https://github.com/owncloud/ocis-proxy/pull/41

--- a/changelog/unreleased/token-header-fix
+++ b/changelog/unreleased/token-header-fix
@@ -1,0 +1,5 @@
+Bugfix: Fix x-access-token in header
+
+We fixed setting the x-access-token in the request header, which was broken before.
+
+https://github.com/owncloud/ocis-proxy/pull/41

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -247,7 +247,10 @@ func loadMiddlewares(cfg *config.Config, l log.Logger) alice.Chain {
 			oidc.Logger(l),
 		)
 
-		uuidMW := middleware.AccountUUID(middleware.Logger(l))
+		uuidMW := middleware.AccountUUID(
+			middleware.Logger(l),
+			middleware.TokenManagerConfig(cfg.TokenManager),
+		)
 
 		return alice.New(middleware.RedirectToHTTPS, oidcMW, uuidMW)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	Asset          Asset
 	Policies       []Policy
 	OIDC           *OIDC
+	TokenManager   TokenManager
 	PolicySelector *PolicySelector `mapstructure:"policy_selector"`
 }
 
@@ -102,6 +103,11 @@ type PolicySelector struct {
 // StaticSelectorConf is the config for the static-policy-selector
 type StaticSelectorConf struct {
 	Policy string
+}
+
+// TokenManager is the config for using the reva token manager
+type TokenManager struct {
+	JWTSecret string
 }
 
 // MigrationSelectorConf is the config for the migration-selector

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -99,7 +99,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "debug-token",
 			Value:       "",
-			Usage:       "TokenManager to grant metrics access",
+			Usage:       "Token to grant metrics access",
 			EnvVars:     []string{"PROXY_DEBUG_TOKEN"},
 			Destination: &cfg.Debug.Token,
 		},

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -99,7 +99,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "debug-token",
 			Value:       "",
-			Usage:       "Token to grant metrics access",
+			Usage:       "TokenManager to grant metrics access",
 			EnvVars:     []string{"PROXY_DEBUG_TOKEN"},
 			Destination: &cfg.Debug.Token,
 		},
@@ -156,6 +156,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Usage:       "Secret file for transport encryption",
 			EnvVars:     []string{"PROXY_TRANSPORT_TLS_KEY"},
 			Destination: &cfg.HTTP.TLSKey,
+		},
+		&cli.StringFlag{
+			Name:        "jwt-secret",
+			Value:       "Pive-Fumkiu4",
+			Usage:       "Used to create JWT to talk to reva, should equal reva's jwt-secret",
+			EnvVars:     []string{"PROXY_JWT_SECRET"},
+			Destination: &cfg.TokenManager.JWTSecret,
 		},
 	}
 }

--- a/pkg/middleware/account_uuid.go
+++ b/pkg/middleware/account_uuid.go
@@ -103,7 +103,7 @@ func AccountUUID(opts ...AccountMiddlewareOption) func(next http.Handler) http.H
 				return
 			}
 
-			w.Header().Set("x-access-token", token)
+			r.Header.Set("x-access-token", token)
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/pkg/middleware/account_uuid.go
+++ b/pkg/middleware/account_uuid.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"github.com/owncloud/ocis-proxy/pkg/config"
 	"net/http"
 
 	revauser "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -19,6 +20,8 @@ type AccountMiddlewareOption func(o *AccountMiddlewareOptions)
 type AccountMiddlewareOptions struct {
 	// Logger to use for logging, must be set
 	Logger log.Logger
+	// TokenManagerConfig for communicating with the reva token manager
+	TokenManagerConfig config.TokenManager
 }
 
 // Logger provides a function to set the logger option.
@@ -28,21 +31,32 @@ func Logger(l log.Logger) AccountMiddlewareOption {
 	}
 }
 
-// AccountUUID provides a middleware which mints a jwt and adds it to the proxied request based
-// on the oidc-claims
-func AccountUUID(opts ...AccountMiddlewareOption) func(next http.Handler) http.Handler {
+// TokenManagerConfig provides a function to set the token manger config option.
+func TokenManagerConfig(cfg config.TokenManager) AccountMiddlewareOption {
+	return func(o *AccountMiddlewareOptions) {
+		o.TokenManagerConfig = cfg
+	}
+}
+
+func newAccountUUIDOptions(opts ...AccountMiddlewareOption) AccountMiddlewareOptions {
 	opt := AccountMiddlewareOptions{}
 	for _, o := range opts {
 		o(&opt)
 	}
+	return opt
+}
+
+// AccountUUID provides a middleware which mints a jwt and adds it to the proxied request based
+// on the oidc-claims
+func AccountUUID(opts ...AccountMiddlewareOption) func(next http.Handler) http.Handler {
+	opt := newAccountUUIDOptions(opts...)
 
 	return func(next http.Handler) http.Handler {
 		// TODO: handle error
 		tokenManager, err := jwt.New(map[string]interface{}{
-			"secret":  "Pive-Fumkiu4",
+			"secret":  opt.TokenManagerConfig.JWTSecret,
 			"expires": int64(60),
 		})
-
 		if err != nil {
 			opt.Logger.Fatal().Err(err).Msgf("Could not initialize token-manager")
 		}


### PR DESCRIPTION
Minted token was not set on the request header, but on the header of the response writer instead. Fixed that. Also made the jwt secret for the reva token manager configurable, to give us more flexibility there.