### PR TITLE
Fix that accounts services response is ignored

### DIFF
--- a/changelog/unreleased/cache-miss-fix
+++ b/changelog/unreleased/cache-miss-fix
@@ -1,0 +1,6 @@
+Bugfix: Accounts service response was ignored
+
+We fixed an error in the AccountUUID middleware that was responsible for ignoring an account uuid
+provided by the accounts service.
+
+https://github.com/owncloud/ocis-proxy/pull/43

--- a/pkg/middleware/account_uuid.go
+++ b/pkg/middleware/account_uuid.go
@@ -95,13 +95,14 @@ func AccountUUID(opts ...AccountMiddlewareOption) func(next http.Handler) http.H
 				}
 
 				uuid = resp.Payload.Account.Uuid
+			} else {
+				uuid, ok = entry.V.(string)
+				if !ok {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
 			}
 
-			uuid, ok = entry.V.(string)
-			if !ok {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
 
 			l.Debug().Interface("claims", claims).Interface("uuid", uuid).Msgf("Associated claims with uuid")
 			token, err := tokenManager.MintToken(r.Context(), &revauser.User{


### PR DESCRIPTION
The request to the accounts service is written to the cache, but the
retrieved uuid was not used, because it was overwritten by the value
from the (non-existant) cache entry.

