### PR TITLE
Fix user claims on x-access-token Reva header

### DIFF
--- a/pkg/middleware/account_uuid.go
+++ b/pkg/middleware/account_uuid.go
@@ -2,8 +2,10 @@ package middleware
 
 import (
 	"context"
-	"github.com/owncloud/ocis-proxy/pkg/config"
 	"net/http"
+	"strings"
+
+	"github.com/owncloud/ocis-proxy/pkg/config"
 
 	revauser "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/pkg/token/manager/jwt"
@@ -103,13 +105,13 @@ func AccountUUID(opts ...AccountMiddlewareOption) func(next http.Handler) http.H
 				}
 			}
 
-
 			l.Debug().Interface("claims", claims).Interface("uuid", uuid).Msgf("Associated claims with uuid")
 			token, err := tokenManager.MintToken(r.Context(), &revauser.User{
 				Id: &revauser.UserId{
 					OpaqueId: uuid,
 				},
-				Username: claims.Email,
+				Username:    strings.ToLower(claims.Name),
+				DisplayName: claims.Name,
 			})
 
 			if err != nil {

--- a/pkg/middleware/openidconnect.go
+++ b/pkg/middleware/openidconnect.go
@@ -19,7 +19,9 @@ var (
 	ErrInvalidToken = errors.New("invalid or missing token")
 
 	// svcCache caches requests for given services to prevent round trips to the service
-	svcCache = cache.NewCache()
+	svcCache = cache.NewCache(
+		cache.Size(256),
+	)
 
 	// ClaimsKey works as a context key for user claims
 	ClaimsKey interface{} = "claims"


### PR DESCRIPTION
Currently Reva `x-access-token` header expects a `username` field to exist. If we are crafting our own token, bypassing reva authentication, then we need to stick to its format. An example of a Reva generated access token:

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNTkxOTU4MjMzLCJpYXQiOjE1OTE5NTQ2MzMsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0OjkyMDAiLCJ1c2VyIjp7ImlkIjp7ImlkcCI6Imh0dHBzOi8vbG9jYWxob3N0OjkyMDAiLCJvcGFxdWVfaWQiOiJlaW5zdGVpbiJ9LCJ1c2VybmFtZSI6ImVpbnN0ZWluIiwibWFpbCI6ImVpbnN0ZWluQGV4YW1wbGUub3JnIiwiZGlzcGxheV9uYW1lIjoiRWluc3RlaW4ifX0.qbfV9v5oLCvm-TKCL0u1Y9HX40yZI_fH_-YuDPHakwQ
```

A reference of an access token created by the UUID Middleware:

```
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNTkxOTU1NzkzLCJpYXQiOjE1OTE5NTU3MzMsInVzZXIiOnsiaWQiOnsib3BhcXVlX2lkIjoiMjAwfmE1NGJmMTU0LWU2YTUtNGU5Ni04NTFiLWE1NmM5ZjZjMWZjZSJ9LCJ1c2VybmFtZSI6ImVpbnN0ZWluIiwiZGlzcGxheV9uYW1lIjoiRWluc3RlaW4ifX0.UQsM7kwxfb0uRbk_GU8muJ8g9tcfXeWhqdYZzDpILJ4
```

Note that we're still using the reva user opaqueId as it is intended, since a UUID is opaque, by design.