### PR TITLE
return groups

### DIFF
--- a/changelog/unreleased/user-and-group-name-mapping
+++ b/changelog/unreleased/user-and-group-name-mapping
@@ -1,0 +1,6 @@
+Change: mint new username property in the reva token
+
+An accounts username is now taken from the on_premises_sam_account_name property instead of the preferred_name.
+Furthermore the group name (also from on_premises_sam_account_name property) is now minted into the token as well.
+
+https://github.com/owncloud/ocis-proxy/pull/62


### PR DESCRIPTION
An accounts username is now taken from the on_premises_sam_account_name property instead of the preferred_name.
Furthermore the group name (also from on_premises_sam_account_name property) is now minted into the token as well.
