### PR TITLE
only send createhome requests if the account has been migrated

### DIFF
--- a/changelog/unreleased/create-home-if-migrated.md
+++ b/changelog/unreleased/create-home-if-migrated.md
@@ -1,0 +1,6 @@
+Enhancement: only send create home request if an account has been migrated 
+
+This change adds a check if an account has been migrated by getting it from the
+ocis-accounts service. If no account is returned it means it hasn't been migrated.
+
+https://github.com/owncloud/ocis-proxy/issues/52

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -295,6 +295,7 @@ func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alic
 		chMW := middleware.CreateHome(
 			middleware.Logger(l),
 			middleware.RevaGatewayClient(sc),
+			middleware.AccountsClient(accounts),
 		)
 
 		return alice.New(middleware.RedirectToHTTPS, oidcMW, uuidMW, chMW)

--- a/pkg/middleware/create_home.go
+++ b/pkg/middleware/create_home.go
@@ -25,12 +25,16 @@ func CreateHome(opts ...Option) func(next http.Handler) http.Handler {
 				"secret": opt.TokenManagerConfig.JWTSecret,
 			})
 			if err != nil {
-				opt.Logger.Err(err).Msg("error creating tokenManager")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
 			token := r.Header.Get("x-access-token")
+			if token == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			user, err := tokenManager.DismantleToken(r.Context(), token)
 			if err != nil {
 				opt.Logger.Err(err).Msg("error getting user from access token")

--- a/pkg/middleware/create_home.go
+++ b/pkg/middleware/create_home.go
@@ -7,6 +7,9 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	tokenpkg "github.com/cs3org/reva/pkg/token"
+	"github.com/cs3org/reva/pkg/token/manager/jwt"
+	"github.com/micro/go-micro/v2/errors"
+	"github.com/owncloud/ocis-accounts/pkg/proto/v0"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -16,7 +19,38 @@ func CreateHome(opts ...Option) func(next http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			accounts := opt.AccountsClient
+
+			tokenManager, err := jwt.New(map[string]interface{}{
+				"secret": opt.TokenManagerConfig.JWTSecret,
+			})
+			if err != nil {
+				opt.Logger.Err(err).Msg("error creating tokenManager")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
 			token := r.Header.Get("x-access-token")
+			user, err := tokenManager.DismantleToken(r.Context(), token)
+			if err != nil {
+				opt.Logger.Err(err).Msg("error getting user from access token")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, err = accounts.GetAccount(r.Context(), &proto.GetAccountRequest{
+				Id: user.Id.OpaqueId,
+			})
+			if err != nil {
+				e := errors.Parse(err.Error())
+				if e.Code == http.StatusNotFound {
+					opt.Logger.Debug().Msgf("account with id %s not found", user.Id.OpaqueId)
+					next.ServeHTTP(w, r)
+					return
+				}
+				opt.Logger.Err(err).Msgf("error getting user with id %s from accounts service", user.Id.OpaqueId)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 
 			// we need to pass the token to authenticate the CreateHome request.
 			//ctx := tokenpkg.ContextSetToken(r.Context(), token)


### PR DESCRIPTION
This change adds a check if an account has been migrated by getting it from the ocis-accounts service. If no account is returned it means it hasn't been migrated.

Closes #52 