### PR TITLE
[Tracing]: Start root span on Proxy

### DIFF
--- a/changelog/unreleased/root-tracing.md
+++ b/changelog/unreleased/root-tracing.md
@@ -1,4 +1,4 @@
-Enhancement: Create a root span on proxy that propagates down to consumers.
+Enhancement: Create a root span on proxy that propagates down to consumers
 
 In order to propagate and correctly associate a span with a request we need a root span that gets sent to other services.
 

--- a/changelog/unreleased/root-tracing.md
+++ b/changelog/unreleased/root-tracing.md
@@ -1,0 +1,5 @@
+Enhancement: Create a root span on proxy that propagates down to consumers.
+
+In order to propagate and correctly associate a span with a request we need a root span that gets sent to other services.
+
+https://github.com/owncloud/ocis-proxy/pull/64

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,7 @@ github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/cheggaaa/pb v1.0.28/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,6 +43,8 @@ func Server(cfg *config.Config) *cli.Command {
 		Usage: "Start integrated server",
 		Flags: flagset.ServerWithConfig(cfg),
 		Before: func(ctx *cli.Context) error {
+			l := NewLogger(cfg)
+			l.Debug().Str("tracing", strconv.FormatBool(cfg.Tracing.Enabled)).Msg("init: before")
 			if cfg.HTTP.Root != "/" {
 				cfg.HTTP.Root = strings.TrimSuffix(cfg.HTTP.Root, "/")
 			}

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -77,7 +77,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "tracing-collector",
-			Value:       "",
+			Value:       "http://localhost:14268/api/traces",
 			Usage:       "Endpoint for the collector",
 			EnvVars:     []string{"PROXY_TRACING_COLLECTOR"},
 			Destination: &cfg.Tracing.Collector,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,12 +1,16 @@
 package proxy
 
 import (
-	"github.com/owncloud/ocis-proxy/pkg/proxy/policy"
+	"context"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/owncloud/ocis-proxy/pkg/proxy/policy"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	"go.opencensus.io/trace"
 
 	"github.com/owncloud/ocis-pkg/v2/log"
 	"github.com/owncloud/ocis-proxy/pkg/config"
@@ -18,6 +22,8 @@ type MultiHostReverseProxy struct {
 	Directors      map[string]map[config.RouteType]map[string]func(req *http.Request)
 	PolicySelector policy.Selector
 	logger         log.Logger
+	propagator     tracecontext.HTTPFormat
+	config         *config.Config
 }
 
 // NewMultiHostReverseProxy undocummented
@@ -27,6 +33,7 @@ func NewMultiHostReverseProxy(opts ...Option) *MultiHostReverseProxy {
 	rp := &MultiHostReverseProxy{
 		Directors: make(map[string]map[config.RouteType]map[string]func(req *http.Request)),
 		logger:    options.Logger,
+		config:    options.Config,
 	}
 
 	if options.Config.Policies == nil {
@@ -140,6 +147,16 @@ func (p *MultiHostReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request
 			Msgf("policy %v is not configured", pol)
 	}
 
+	var ctx context.Context
+	var span *trace.Span
+
+	// Start root span.
+	if p.config.Tracing.Enabled {
+		ctx, span = trace.StartSpan(context.Background(), r.URL.String())
+		defer span.End()
+		p.propagator.SpanContextToRequest(span.SpanContext(), r)
+	}
+
 Loop:
 	for _, rt := range config.RouteTypes {
 		var handler func(string, url.URL) bool
@@ -175,7 +192,7 @@ Loop:
 	}
 
 	// Call upstream ServeHTTP
-	p.ReverseProxy.ServeHTTP(w, r)
+	p.ReverseProxy.ServeHTTP(w, r.WithContext(ctx))
 }
 
 func (p MultiHostReverseProxy) queryRouteMatcher(endpoint string, target url.URL) bool {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -147,7 +147,7 @@ func (p *MultiHostReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request
 			Msgf("policy %v is not configured", pol)
 	}
 
-	var ctx context.Context
+	ctx := context.Background()
 	var span *trace.Span
 
 	// Start root span.


### PR DESCRIPTION
[We use an HTTP propagator](https://pkg.go.dev/go.opencensus.io/plugin/ochttp/propagation/tracecontext?tab=doc) to go beyond our process boundary. Essentially the span gets serialized in the request context and travels along with the HTTP request. You can test this changes by starting the ocis set of services:

`ocis server`

stop the proxy: `ocis kill proxy`
start a new proxy process with the changes from this PR:

```bash
# on the root of this repository, on this PR branch
go run cmd/ocis-proxy/main.go --log-level debug server --tracing-enabled=true
```

Start jaeger default container:

```bash
docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
  -p 5775:5775/udp \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 14268:14268 \
  -p 14250:14250 \
  -p 9411:9411 \
  jaegertracing/all-in-one:1.18
```

on the browser: https://localhost:9200, sign in, do some actions.
go to: http://localhost:16686
on the far left, the `Service` dropdown select **proxy**
see some traces.