### PR TITLE
Add Accounts UI routes

### DIFF
--- a/changelog/unreleased/add-accounts-ui-routes.md
+++ b/changelog/unreleased/add-accounts-ui-routes.md
@@ -1,0 +1,9 @@
+Enhancement: Add Accounts UI routes
+
+The accounts service has a ui that requires routing
+- `/api/v0/accounts` and
+- `/accounts.js`
+
+to http://localhost:9181
+
+https://github.com/owncloud/ocis-proxy/pull/65

--- a/config/proxy-example-migration.json
+++ b/config/proxy-example-migration.json
@@ -62,7 +62,15 @@
         {
           "endpoint": "/data",
           "backend": "http://localhost:9140"
-        }
+        },
+        {
+					"endpoint": "/api/v0/accounts",
+					"backend":  "http://localhost:9181"
+				},
+				{
+          "endpoint": "/accounts.js",
+					"backend":  "http://localhost:9181"
+				}
       ]
     },
     {

--- a/config/proxy-example.json
+++ b/config/proxy-example.json
@@ -58,7 +58,15 @@
         {
           "endpoint": "/data",
           "backend": "http://localhost:9140"
-        }
+        },
+        {
+					"endpoint": "/api/v0/accounts",
+					"backend":  "http://localhost:9181"
+				},
+				{
+          "endpoint": "/accounts.js",
+					"backend":  "http://localhost:9181"
+				}
       ]
     },
     {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -282,6 +282,16 @@ func defaultPolicies() []config.Policy {
 					Endpoint: "/data",
 					Backend:  "http://localhost:9140",
 				},
+				// if we were using the go micro api gateway we could look up the endpoint in the registry dynamically
+				{
+					Endpoint: "/api/v0/accounts",
+					Backend:  "http://localhost:9181",
+				},
+				// TODO the lookup needs a better mechanism
+				{
+					Endpoint: "/accounts.js",
+					Backend:  "http://localhost:9181",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
The accounts service has a ui that requires routing
- `/api/v0/accounts` and
- `/accounts.js`

to http://localhost:9181