### PR TITLE
Change: Add OIDC config flags

### DIFF
--- a/changelog/unreleased/add-oidc-config-flags.md
+++ b/changelog/unreleased/add-oidc-config-flags.md
@@ -1,0 +1,11 @@
+Change: Add OIDC config flags
+
+To authenticate requests with an oidc provider we added two environment variables:
+- `PROXY_OIDC_ISSUER="https://localhost:9200"` and
+- `PROXY_OIDC_INSECURE=true`
+
+This changes ocis-proxy to now load the oidc-middleware by default, requiring a bearer token and exchanging the email in the OIDC claims for an account id at the ocis-accounts service.
+
+Setting `PROXY_OIDC_ISSUER=""` will disable the OIDC middleware.
+
+https://github.com/owncloud/ocis-proxy/pull/66

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -245,7 +245,7 @@ func Server(cfg *config.Config) *cli.Command {
 }
 
 func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alice.Chain {
-	if cfg.OIDC != nil {
+	if cfg.OIDC.Issuer != "" {
 		l.Info().Msg("Loading OIDC-Middleware")
 		l.Debug().Interface("oidc_config", cfg.OIDC).Msg("OIDC-Config")
 
@@ -265,7 +265,7 @@ func loadMiddlewares(ctx context.Context, l log.Logger, cfg *config.Config) alic
 		// it will fetch the keys from the issuer using the .well-known
 		// endpoint
 		provider := func() (middleware.OIDCProvider, error) {
-			return oidc.NewProvider(customCtx, cfg.OIDC.Endpoint)
+			return oidc.NewProvider(customCtx, cfg.OIDC.Issuer)
 		}
 
 		oidcMW := middleware.OpenIDConnect(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,7 +85,7 @@ type Config struct {
 	Tracing        Tracing
 	Asset          Asset
 	Policies       []Policy
-	OIDC           *OIDC
+	OIDC           OIDC
 	TokenManager   TokenManager
 	PolicySelector *PolicySelector `mapstructure:"policy_selector"`
 	Reva           Reva
@@ -94,7 +94,7 @@ type Config struct {
 // OIDC is the config for the OpenID-Connect middleware. If set the proxy will try to authenticate every request
 // with the configured oidc-provider
 type OIDC struct {
-	Endpoint string
+	Issuer   string
 	Insecure bool
 }
 

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -171,5 +171,23 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"PROXY_REVA_GATEWAY_ADDR"},
 			Destination: &cfg.Reva.Address,
 		},
+
+		// OIDC
+
+		&cli.StringFlag{
+			Name:        "oidc-issuer",
+			Value:       "https://localhost:9200",
+			Usage:       "OIDC issuer",
+			EnvVars:     []string{"PROXY_OIDC_ISSUER"},
+			Destination: &cfg.OIDC.Issuer,
+		},
+		&cli.BoolFlag{
+			Name:        "oidc-insecure",
+			Value:       true,
+			Usage:       "OIDC allow insecure communication",
+			EnvVars:     []string{"PROXY_OIDC_INSECURE"},
+			Destination: &cfg.OIDC.Insecure,
+		},
 	}
+
 }

--- a/pkg/proxy/proxy_integration_test.go
+++ b/pkg/proxy/proxy_integration_test.go
@@ -216,7 +216,7 @@ func testConfig(policy []config.Policy) *config.Config {
 		Tracing:        config.Tracing{},
 		Asset:          config.Asset{},
 		Policies:       policy,
-		OIDC:           nil,
+		OIDC:           config.OIDC{},
 		PolicySelector: nil,
 	}
 }


### PR DESCRIPTION
To authenticate requests with an oidc provider we added two environment variables:
- `PROXY_OIDC_ISSUER="https://localhost:9200"` and
- `PROXY_OIDC_INSECURE=true`

This changes ocis-proxy to now load the oidc-middleware by default, requiring a bearer token and exchanging the email in the OIDC claims for an account id at the ocis-accounts service.

Set the PROXY_OIDC_ISSUER to "" the oidc middleware will get disabled