### PR TITLE
Add option to disable TLS

### DIFF
--- a/changelog/unreleased/add-disable-tls.md
+++ b/changelog/unreleased/add-disable-tls.md
@@ -1,0 +1,8 @@
+Enhancement: Add option to disable TLS
+
+Can be used to disable TLS when the ocis-proxy is behind an
+TLS-Terminating reverse proxy.
+
+env PROXY_TLS=false or --tls=false
+
+https://github.com/owncloud/ocis-proxy/issues/71

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ type HTTP struct {
 	Root      string
 	TLSCert   string
 	TLSKey    string
+	TLS       bool
 }
 
 // Tracing defines the available tracing configuration.

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -157,6 +157,13 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"PROXY_TRANSPORT_TLS_KEY"},
 			Destination: &cfg.HTTP.TLSKey,
 		},
+		&cli.BoolFlag{
+			Name:        "tls",
+			Usage:       "Use TLS (disable only if proxy is behind a TLS-terminating reverse-proxy).",
+			EnvVars:     []string{"PROXY_TLS"},
+			Value:       true,
+			Destination: &cfg.HTTP.TLS,
+		},
 		&cli.StringFlag{
 			Name:        "jwt-secret",
 			Value:       "Pive-Fumkiu4",


### PR DESCRIPTION
Can be used to disable TLS when the ocis-proxy is behind an
TLS-Terminating reverse proxy.

env PROXY_TLS=false or cli --tls=false

Closes #71 

