### PR TITLE
prevent segfault in create home middleware

### DIFF
--- a/changelog/unreleased/fix-createhome-segfault.md
+++ b/changelog/unreleased/fix-createhome-segfault.md
@@ -1,0 +1,5 @@
+Bugfix: Provide token configuration from config
+
+Fixed a bug that causes the createHome middleware to crash if the createHome response has no Status set
+
+https://github.com/owncloud/ocis-proxy/pull/76

--- a/pkg/middleware/create_home.go
+++ b/pkg/middleware/create_home.go
@@ -66,11 +66,9 @@ func CreateHome(opts ...Option) func(next http.Handler) http.Handler {
 
 			if err != nil {
 				opt.Logger.Err(err).Msg("error calling CreateHome")
-			}
-
-			if createHomeRes.Status.Code != rpc.Code_CODE_OK {
+			} else if createHomeRes.Status.Code != rpc.Code_CODE_OK {
 				err := status.NewErrorFromCode(createHomeRes.Status.Code, "gateway")
-				opt.Logger.Err(err).Msg("error calling Createhome")
+				opt.Logger.Err(err).Msg("error when calling Createhome")
 			}
 
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
Fixed a bug that causes the createHome middleware to crash if the createHome response has no Status set