### PR TITLE
enable new accounts

### DIFF
--- a/changelog/unreleased/enable-new-accounts.md
+++ b/changelog/unreleased/enable-new-accounts.md
@@ -1,0 +1,5 @@
+Bugfix: enable new accounts by default
+
+When new accounts are created, they also need to be enabled to be useable.
+
+https://github.com/owncloud/ocis-proxy/pull/79

--- a/pkg/middleware/account_uuid.go
+++ b/pkg/middleware/account_uuid.go
@@ -71,6 +71,8 @@ func createAccount(l log.Logger, claims *oidc.StandardClaims, ac acc.AccountsSer
 			OnPremisesSamAccountName: claims.PreferredUsername,
 			Mail:                     claims.Email,
 			CreationType:             "LocalAccount",
+			AccountEnabled:           true,
+			// TODO assign uidnumber and gidnumber? better do that in ocis-accounts as it can keep track of the next numbers
 		},
 	}
 	created, err := ac.CreateAccount(context.Background(), req)


### PR DESCRIPTION
When new accounts are created, they also need to be enabled to be useable. Otherwise we might see sth like this in the logs when a new user tries to log in:
```

2020-07-27T15:27:29Z DBG unmarshalled userinfo claims={"email":"user1@example.org","family_name":"User One","given_name":"user1","iss":"","name":"User One","preferred_username":"user1","sub":"guyRptzBUh7Hoa_89QQteYhQ6Z_cpUBJf3lLYnsxgeYw7TNI9DgeaKXSVaYHGi9_V3820mP-V5kz7CLIECV64w@konnect"} service=proxy userInfo={"email":"user1@example.org","email_verified":false,"profile":"","sub":"guyRptzBUh7Hoa_89QQteYhQ6Z_cpUBJf3lLYnsxgeYw7TNI9DgeaKXSVaYHGi9_V3820mP-V5kz7CLIECV64w@konnect"} | 3001s
-- | --
18503 | 2020-07-27T15:27:29Z DBG using cache entry for mail eq 'user1@example.org' service=proxy | 3001s
18504 | 2020-07-27T15:27:29Z DBG account is disabled account={"creationType":"LocalAccount","id":"189af58e-dd6c-4ae9-a099-9fd48cbafbe5","mail":"user1@example.org","onPremisesSamAccountName":"user1","preferredName":"user1"} service=proxy | 3001s
18505 | 2020-07-27T15:27:32Z DBG Refreshing external service-registration service={"endpoints":[],"metadata":null,"name":"com.owncloud.reva","nodes":[{"address":"0.0.0.0:9142","id":"com.owncloud.reva-1b810d26-baf9-4d4f-a26b-5dcce70bb30d","metadata":{"broker":"http","protocol":"grpc","registry":"mdns","server":"grpc","transport":"grpc"}}],"version":""}

```