### PR TITLE
Fix director selection

### DIFF
--- a/changelog/unreleased/fix-director-selection.md
+++ b/changelog/unreleased/fix-director-selection.md
@@ -1,0 +1,5 @@
+Bugfix: Fix director selection
+
+We fixed a bug where simultaneous requests could be executed on the wrong backend.
+
+https://github.com/owncloud/ocis-proxy/pull/99


### PR DESCRIPTION
Instead of overwriting the director on each request, provide function
for director selection. On concurrent requests the previous
implementation could have caused situations where the request was
performed on a wrong director.

