### PR TITLE
Get rid of cache in account_uuid middleware

### DIFF
--- a/changelog/unreleased/remove-account-caching.md
+++ b/changelog/unreleased/remove-account-caching.md
@@ -1,0 +1,5 @@
+Change: Remove accounts caching
+
+We removed the accounts cache in order to avoid problems with accounts that have been updated in the accounts service.
+
+https://github.com/owncloud/ocis-proxy/pull/100


### PR DESCRIPTION
Accounts can be changed. In that case the cache entries would need to be
invalidated. Since we are keeping accounts in an in-memory index within
ocis-accounts anyway, we can get rid of this kind of optimization for
now.

Fixing https://github.com/owncloud/ocis-accounts/issues/113
