### PR TITLE
Revert "[Tests-Only] prepare drone starlak file for move to internal CI"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -5,8 +5,8 @@ def main(ctx):
 
   stages = [
     docker(ctx, 'amd64'),
-    # docker(ctx, 'arm64'),
-    # docker(ctx, 'arm'),
+    docker(ctx, 'arm64'),
+    docker(ctx, 'arm'),
     binary(ctx, 'linux'),
     binary(ctx, 'darwin'),
     binary(ctx, 'windows'),
@@ -427,8 +427,8 @@ def manifest(ctx):
     ],
     'depends_on': [
       'amd64',
-      # 'arm64',
-      # 'arm',
+      'arm64',
+      'arm',
       'linux',
       'darwin',
       'windows',


### PR DESCRIPTION
Reverts owncloud/ocis-proxy#101

because ARM should be working now on internal drone CI.